### PR TITLE
refactor: set super admin role as own admin

### DIFF
--- a/solidity/contracts/OracleAggregator.sol
+++ b/solidity/contracts/OracleAggregator.sol
@@ -21,8 +21,10 @@ contract OracleAggregator is AccessControl, SimpleOracle, IOracleAggregator {
     address[] memory _initialAdmins
   ) {
     if (_superAdmin == address(0)) revert ZeroAddress();
-    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    // We are setting the super admin role as its own admin so we can transfer it
+    _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
     for (uint256 i; i < _initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialAdmins[i]);
     }

--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -32,8 +32,10 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
     if (address(_registry) == address(0) || address(_underlyingOracle) == address(0) || _superAdmin == address(0)) revert ZeroAddress();
     REGISTRY = _registry;
     UNDERLYING_ORACLE = _underlyingOracle;
-    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    // We are setting the super admin role as its own admin so we can transfer it
+    _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
     for (uint256 i; i < _initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialAdmins[i]);
     }

--- a/solidity/contracts/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/adapters/UniswapV3Adapter.sol
@@ -36,8 +36,10 @@ contract UniswapV3Adapter is AccessControl, SimpleOracle, IUniswapV3Adapter {
     UNISWAP_V3_ORACLE = _initialConfig.uniswapV3Oracle;
     MAX_PERIOD = _initialConfig.maxPeriod;
     MIN_PERIOD = _initialConfig.minPeriod;
-    _setupRole(SUPER_ADMIN_ROLE, _initialConfig.superAdmin);
+    // We are setting the super admin role as its own admin so we can transfer it
+    _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
     for (uint256 i; i < _initialConfig.initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialConfig.initialAdmins[i]);
     }

--- a/solidity/contracts/adapters/UniswapV3Adapter.sol
+++ b/solidity/contracts/adapters/UniswapV3Adapter.sol
@@ -39,7 +39,7 @@ contract UniswapV3Adapter is AccessControl, SimpleOracle, IUniswapV3Adapter {
     // We are setting the super admin role as its own admin so we can transfer it
     _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
-    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    _setupRole(SUPER_ADMIN_ROLE, _initialConfig.superAdmin);
     for (uint256 i; i < _initialConfig.initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialConfig.initialAdmins[i]);
     }

--- a/test/unit/adapters/uniswap-v3-adapter.spec.ts
+++ b/test/unit/adapters/uniswap-v3-adapter.spec.ts
@@ -111,6 +111,10 @@ describe('UniswapV3Adapter', () => {
         const hasRole = await adapter.hasRole(adminRole, admin.address);
         expect(hasRole).to.be.true;
       });
+      then('super admin role is set as super admin role', async () => {
+        const admin = await adapter.getRoleAdmin(superAdminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
       then('super admin role is set as admin role', async () => {
         const admin = await adapter.getRoleAdmin(adminRole);
         expect(admin).to.equal(superAdminRole);

--- a/test/unit/oracle-aggregator.spec.ts
+++ b/test/unit/oracle-aggregator.spec.ts
@@ -81,6 +81,10 @@ describe('OracleAggregator', () => {
         const hasRole = await oracleAggregator.hasRole(adminRole, admin.address);
         expect(hasRole).to.be.true;
       });
+      then('super admin role is set as super admin role', async () => {
+        const admin = await oracleAggregator.getRoleAdmin(superAdminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
       then('super admin role is set as admin role', async () => {
         const admin = await oracleAggregator.getRoleAdmin(adminRole);
         expect(admin).to.equal(superAdminRole);

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -113,6 +113,10 @@ describe('TransformerOracle', () => {
         const hasRole = await transformerOracle.hasRole(adminRole, admin.address);
         expect(hasRole).to.be.true;
       });
+      then('super admin role is set as super admin role', async () => {
+        const admin = await transformerOracle.getRoleAdmin(superAdminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
       then('super admin role is set as admin role', async () => {
         const admin = await transformerOracle.getRoleAdmin(adminRole);
         expect(admin).to.equal(superAdminRole);


### PR DESCRIPTION
We are now setting the super admin role as its own admin, so we can transfer it in the future