### PR TITLE
refactor: move chainlink oracle to new interface

### DIFF
--- a/solidity/contracts/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/StatefulChainlinkOracle.sol
@@ -45,18 +45,26 @@ contract StatefulChainlinkOracle is Governable, IStatefulChainlinkOracle {
     WETH = _WETH;
   }
 
-  /// @inheritdoc IPriceOracle
+  /// @inheritdoc ITokenPriceOracle
   function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
     PricingPlan _plan = _determinePricingPlan(__tokenA, __tokenB);
     return _plan != PricingPlan.NONE;
   }
 
-  /// @inheritdoc IPriceOracle
+  /// @inheritdoc ITokenPriceOracle
+  function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
+    (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
+    PricingPlan _plan = planForPair[__tokenA][__tokenB];
+    return _plan != PricingPlan.NONE;
+  }
+
+  /// @inheritdoc ITokenPriceOracle
   function quote(
     address _tokenIn,
-    uint128 _amountIn,
-    address _tokenOut
+    uint256 _amountIn,
+    address _tokenOut,
+    bytes calldata
   ) external view returns (uint256 _amountOut) {
     (address _tokenA, address _tokenB) = _sortTokens(_tokenIn, _tokenOut);
     PricingPlan _plan = planForPair[_tokenA][_tokenB];
@@ -74,13 +82,21 @@ contract StatefulChainlinkOracle is Governable, IStatefulChainlinkOracle {
     }
   }
 
-  /// @inheritdoc IPriceOracle
-  function reconfigureSupportForPair(address _tokenA, address _tokenB) external {
+  /// @inheritdoc ITokenPriceOracle
+  function addOrModifySupportForPair(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata
+  ) external {
     _addSupportForPair(_tokenA, _tokenB);
   }
 
-  /// @inheritdoc IPriceOracle
-  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) external {
+  /// @inheritdoc ITokenPriceOracle
+  function addSupportForPairIfNeeded(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata
+  ) external {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
     if (planForPair[__tokenA][__tokenB] == PricingPlan.NONE) {
       _addSupportForPair(_tokenA, _tokenB);

--- a/solidity/contracts/test/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/test/StatefulChainlinkOracle.sol
@@ -47,6 +47,14 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
     return _callRegistry(_quote, _base);
   }
 
+  function setPlanForPair(
+    address _tokenA,
+    address _tokenB,
+    PricingPlan _plan
+  ) external {
+    planForPair[_tokenA][_tokenB] = _plan;
+  }
+
   function _determinePricingPlan(address _tokenA, address _tokenB) internal view override returns (PricingPlan) {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
     MockedPricingPlan memory _plan = _pricingPlan[__tokenA][__tokenB];

--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -2,46 +2,11 @@
 pragma solidity >=0.5.0;
 
 import '@chainlink/contracts/src/v0.8/interfaces/FeedRegistryInterface.sol';
-
-/// @title The interface for an oracle that provides price quotes
-/// @notice These methods allow users to add support for pairs, and then ask for quotes
-interface IPriceOracle {
-  /// @notice Returns whether this oracle can support this pair of tokens
-  /// @dev _tokenA and _tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-  /// @param _tokenA One of the pair's tokens
-  /// @param _tokenB The other of the pair's tokens
-  /// @return Whether the given pair of tokens can be supported by the oracle
-  function canSupportPair(address _tokenA, address _tokenB) external view returns (bool);
-
-  /// @notice Returns a quote, based on the given tokens and amount
-  /// @param _tokenIn The token that will be provided
-  /// @param _amountIn The amount that will be provided
-  /// @param _tokenOut The token we would like to quote
-  /// @return _amountOut How much _tokenOut will be returned in exchange for _amountIn amount of _tokenIn
-  function quote(
-    address _tokenIn,
-    uint128 _amountIn,
-    address _tokenOut
-  ) external view returns (uint256 _amountOut);
-
-  /// @notice Reconfigures support for a given pair. This function will let the oracle take some actions to configure the pair, in
-  /// preparation for future quotes. Can be called many times in order to let the oracle re-configure for a new context.
-  /// @dev Will revert if pair cannot be supported. _tokenA and _tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-  /// @param _tokenA One of the pair's tokens
-  /// @param _tokenB The other of the pair's tokens
-  function reconfigureSupportForPair(address _tokenA, address _tokenB) external;
-
-  /// @notice Adds support for a given pair if the oracle didn't support it already. If called for a pair that is already supported,
-  /// then nothing will happen. This function will let the oracle take some actions to configure the pair, in preparation for future quotes.
-  /// @dev Will revert if pair cannot be supported. _tokenA and _tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
-  /// @param _tokenA One of the pair's tokens
-  /// @param _tokenB The other of the pair's tokens
-  function addSupportForPairIfNeeded(address _tokenA, address _tokenB) external;
-}
+import './ITokenPriceOracle.sol';
 
 /// @title An implementation of IPriceOracle that uses Chainlink feeds
 /// @notice This oracle will attempt to use all available feeds to determine prices between pairs
-interface IStatefulChainlinkOracle is IPriceOracle {
+interface IStatefulChainlinkOracle is ITokenPriceOracle {
   /// @notice The plan that will be used to calculate quotes for a given pair
   enum PricingPlan {
     // There is no plan calculated

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -133,7 +133,7 @@ describe('StatefulChainlinkOracle', () => {
     when('there is a pricing plan', () => {
       let isAlreadySupported: boolean;
       given(async () => {
-        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
+        await chainlinkOracle.setPlanForPair(TOKEN_A, TOKEN_B, A_PLAN);
         isAlreadySupported = await chainlinkOracle.isPairAlreadySupported(TOKEN_A, TOKEN_B);
       });
       then('pair is already supported', async () => {
@@ -143,7 +143,7 @@ describe('StatefulChainlinkOracle', () => {
     when('sending the tokens in inverse order', () => {
       let isAlreadySupported: boolean;
       given(async () => {
-        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
+        await chainlinkOracle.setPlanForPair(TOKEN_A, TOKEN_B, A_PLAN);
         isAlreadySupported = await chainlinkOracle.isPairAlreadySupported(TOKEN_B, TOKEN_A);
       });
       then('pair is already supported', async () => {

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -119,11 +119,44 @@ describe('StatefulChainlinkOracle', () => {
     });
   });
 
-  describe('reconfigureSupportForPair', () => {
+  describe('isPairAlreadySupported', () => {
+    when('there is no pricing plan', () => {
+      let isAlreadySupported: boolean;
+      given(async () => {
+        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, NO_PLAN);
+        isAlreadySupported = await chainlinkOracle.isPairAlreadySupported(TOKEN_A, TOKEN_B);
+      });
+      then('pair is not already supported', async () => {
+        expect(isAlreadySupported).to.be.false;
+      });
+    });
+    when('there is a pricing plan', () => {
+      let isAlreadySupported: boolean;
+      given(async () => {
+        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
+        isAlreadySupported = await chainlinkOracle.isPairAlreadySupported(TOKEN_A, TOKEN_B);
+      });
+      then('pair is already supported', async () => {
+        expect(isAlreadySupported).to.be.true;
+      });
+    });
+    when('sending the tokens in inverse order', () => {
+      let isAlreadySupported: boolean;
+      given(async () => {
+        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
+        isAlreadySupported = await chainlinkOracle.isPairAlreadySupported(TOKEN_B, TOKEN_A);
+      });
+      then('pair is already supported', async () => {
+        expect(isAlreadySupported).to.be.true;
+      });
+    });
+  });
+
+  describe('addOrModifySupportForPair', () => {
     when(`the function is called`, () => {
       given(async () => {
         await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
-        await chainlinkOracle.reconfigureSupportForPair(TOKEN_A, TOKEN_B);
+        await chainlinkOracle.addOrModifySupportForPair(TOKEN_A, TOKEN_B, []);
       });
       then(`then the internal add support is called directly`, async () => {
         expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.true;
@@ -139,18 +172,18 @@ describe('StatefulChainlinkOracle', () => {
         await chainlinkOracle.reset(TOKEN_A, TOKEN_B);
       });
       then('internal add support is not called', async () => {
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B);
+        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B, []);
         expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.false;
       });
       then('internal add support is not called even if tokens are inverted', async () => {
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_B, TOKEN_A);
+        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_B, TOKEN_A, []);
         expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.false;
       });
     });
     when('pair is not defined yet', () => {
       given(async () => {
         await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B);
+        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B, []);
       });
       then('internal add support is called', async () => {
         expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.true;


### PR DESCRIPTION
We are now refactoring the Chainlink Oracle so that it implements the new `ITokenPriceOracle` interface