### PR TITLE
feat: remove usd stablecoins

### DIFF
--- a/solidity/contracts/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/StatefulChainlinkOracle.sol
@@ -51,7 +51,7 @@ contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
     _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
-    for (uint256 i; i < _initialAdmins.length; i++) {
+    for (uint256 i = 0; i < _initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialAdmins[i]);
     }
   }
@@ -128,6 +128,14 @@ contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
       _shouldBeConsideredUSD[_addresses[i]] = true;
     }
     emit TokensConsideredUSD(_addresses);
+  }
+
+  /// @inheritdoc IStatefulChainlinkOracle
+  function removeUSDStablecoins(address[] calldata _addresses) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i = 0; i < _addresses.length; i++) {
+      _shouldBeConsideredUSD[_addresses[i]] = false;
+    }
+    emit TokensNoLongerConsideredUSD(_addresses);
   }
 
   /// @inheritdoc IStatefulChainlinkOracle

--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -36,6 +36,12 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
   /// @param tokens The new tokens
   event TokensConsideredUSD(address[] tokens);
 
+  /**
+   * @notice Emitted when tokens should no longer be considered USD
+   * @param tokens The tokens to no longer consider USD
+   */
+  event TokensNoLongerConsideredUSD(address[] tokens);
+
   /// @notice Emitted when new mappings are added
   /// @param tokens The tokens
   /// @param mappings Their new mappings
@@ -88,6 +94,13 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
   /// @notice Adds new tokens that should be considered USD stablecoins
   /// @param _addresses The addresses of the tokens
   function addUSDStablecoins(address[] calldata _addresses) external;
+
+  /**
+   * @notice Defines that the given tokens should not be considered USD stablecoins anymore
+   * @dev Can only be called by an admin
+   * @param addresses The tokens that should no longer be considered USD stablecoins
+   */
+  function removeUSDStablecoins(address[] calldata addresses) external;
 
   /// @notice Adds new token mappings
   /// @param _addresses The addresses of the tokens

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -274,6 +274,31 @@ describe('StatefulChainlinkOracle', () => {
     });
   });
 
+  describe('removeUSDStablecoins', () => {
+    when('function is called by admin', () => {
+      const TOKEN_ADDRESS = wallet.generateRandomAddress();
+      let tx: TransactionResponse;
+      given(async () => {
+        await chainlinkOracle.connect(admin).addUSDStablecoins([TOKEN_ADDRESS]);
+        tx = await chainlinkOracle.connect(admin).removeUSDStablecoins([TOKEN_ADDRESS]);
+      });
+      then('address is no longer considered USD', async () => {
+        expect(await chainlinkOracle.isUSD(TOKEN_ADDRESS)).to.be.false;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(chainlinkOracle, 'TokensNoLongerConsideredUSD').withArgs([TOKEN_ADDRESS]);
+      });
+    });
+
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => chainlinkOracle,
+      funcAndSignature: 'removeUSDStablecoins(address[])',
+      params: [[wallet.generateRandomAddress()]],
+      role: () => adminRole,
+      addressWithRole: () => admin,
+    });
+  });
+
   describe('addMappings', () => {
     when('input sizes do not match', () => {
       then('tx is reverted with reason', async () => {


### PR DESCRIPTION
We are now adding `removeUSDStablecoins`, because as @nchamo put it, it should have been there all along 😅 