### PR TITLE
refactor: implement simple oracle

### DIFF
--- a/solidity/contracts/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/StatefulChainlinkOracle.sol
@@ -4,9 +4,10 @@ pragma solidity >=0.8.7 <0.9.0;
 import '@openzeppelin/contracts/access/AccessControl.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import '@chainlink/contracts/src/v0.8/Denominations.sol';
+import './base/SimpleOracle.sol';
 import '../interfaces/IStatefulChainlinkOracle.sol';
 
-contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
+contract StatefulChainlinkOracle is AccessControl, SimpleOracle, IStatefulChainlinkOracle {
   bytes32 public constant SUPER_ADMIN_ROLE = keccak256('SUPER_ADMIN_ROLE');
   bytes32 public constant ADMIN_ROLE = keccak256('ADMIN_ROLE');
 
@@ -64,10 +65,9 @@ contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
   }
 
   /// @inheritdoc ITokenPriceOracle
-  function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
+  function isPairAlreadySupported(address _tokenA, address _tokenB) public view override(ITokenPriceOracle, SimpleOracle) returns (bool) {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
-    PricingPlan _plan = planForPair[__tokenA][__tokenB];
-    return _plan != PricingPlan.NONE;
+    return planForPair[__tokenA][__tokenB] != PricingPlan.NONE;
   }
 
   /// @inheritdoc ITokenPriceOracle
@@ -93,28 +93,11 @@ contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
     }
   }
 
-  /// @inheritdoc ITokenPriceOracle
-  function addOrModifySupportForPair(
+  function _addOrModifySupportForPair(
     address _tokenA,
     address _tokenB,
     bytes calldata
-  ) external {
-    _addSupportForPair(_tokenA, _tokenB);
-  }
-
-  /// @inheritdoc ITokenPriceOracle
-  function addSupportForPairIfNeeded(
-    address _tokenA,
-    address _tokenB,
-    bytes calldata
-  ) external {
-    (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
-    if (planForPair[__tokenA][__tokenB] == PricingPlan.NONE) {
-      _addSupportForPair(_tokenA, _tokenB);
-    }
-  }
-
-  function _addSupportForPair(address _tokenA, address _tokenB) internal virtual {
+  ) internal virtual override {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
     PricingPlan _plan = _determinePricingPlan(__tokenA, __tokenB);
     if (_plan == PricingPlan.NONE) revert PairNotSupported();
@@ -161,6 +144,14 @@ contract StatefulChainlinkOracle is AccessControl, IStatefulChainlinkOracle {
       address _mapping = _tokenMappings[_token];
       return _mapping != address(0) ? _mapping : _token;
     }
+  }
+
+  /// @inheritdoc IERC165
+  function supportsInterface(bytes4 _interfaceId) public view override(AccessControl, BaseOracle) returns (bool) {
+    return
+      _interfaceId == type(IStatefulChainlinkOracle).interfaceId ||
+      AccessControl.supportsInterface(_interfaceId) ||
+      BaseOracle.supportsInterface(_interfaceId);
   }
 
   /** Handles prices when the pair is either ETH/USD, token/ETH or token/USD */

--- a/solidity/contracts/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/StatefulChainlinkOracle.sol
@@ -79,7 +79,7 @@ contract StatefulChainlinkOracle is AccessControl, SimpleOracle, IStatefulChainl
   ) external view returns (uint256 _amountOut) {
     (address _tokenA, address _tokenB) = _sortTokens(_tokenIn, _tokenOut);
     PricingPlan _plan = planForPair[_tokenA][_tokenB];
-    if (_plan == PricingPlan.NONE) revert PairNotSupported();
+    if (_plan == PricingPlan.NONE) revert PairNotSupportedYet(_tokenA, _tokenB);
 
     int8 _inDecimals = _getDecimals(_tokenIn);
     int8 _outDecimals = _getDecimals(_tokenOut);
@@ -100,7 +100,7 @@ contract StatefulChainlinkOracle is AccessControl, SimpleOracle, IStatefulChainl
   ) internal virtual override {
     (address __tokenA, address __tokenB) = _sortTokens(_tokenA, _tokenB);
     PricingPlan _plan = _determinePricingPlan(__tokenA, __tokenB);
-    if (_plan == PricingPlan.NONE) revert PairNotSupported();
+    if (_plan == PricingPlan.NONE) revert PairCannotBeSupported(_tokenA, _tokenB);
     planForPair[__tokenA][__tokenB] = _plan;
     emit AddedSupportForPairInChainlinkOracle(__tokenA, __tokenB);
   }

--- a/solidity/contracts/test/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/test/StatefulChainlinkOracle.sol
@@ -10,7 +10,6 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
     bool isSet;
   }
 
-  mapping(address => mapping(address => bool)) public addSupportForPairCalled;
   mapping(address => mapping(address => MockedPricingPlan)) private _pricingPlan;
 
   constructor(
@@ -22,17 +21,12 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
     address[] memory _initialAdmins
   ) StatefulChainlinkOracle(_WETH, _registry, _maxDelay, _superAdmin, _initialAdmins) {}
 
-  function internalAddSupportForPair(address _tokenA, address _tokenB) external {
-    _addSupportForPair(_tokenA, _tokenB);
-  }
-
-  function _addSupportForPair(address _tokenA, address _tokenB) internal override {
-    addSupportForPairCalled[_tokenA][_tokenB] = true;
-    super._addSupportForPair(_tokenA, _tokenB);
-  }
-
-  function reset(address _tokenA, address _tokenB) external {
-    delete addSupportForPairCalled[_tokenA][_tokenB];
+  function internalAddOrModifySupportForPair(
+    address _tokenA,
+    address _tokenB,
+    bytes calldata _data
+  ) external {
+    _addOrModifySupportForPair(_tokenA, _tokenB, _data);
   }
 
   function setPricingPlan(

--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -63,9 +63,6 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
   /// @notice Thrown when the given max delay is zero
   error ZeroMaxDelay();
 
-  /// @notice Thrown when trying to configure a pair that is not supported
-  error PairNotSupported();
-
   /// @notice Thrown when the input for adding mappings in invalid
   error InvalidMappingsInput();
 

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -3,7 +3,17 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { ethers } from 'hardhat';
 import { behaviours, wallet } from '@utils';
 import { given, then, when } from '@utils/bdd';
-import { FeedRegistryInterface, StatefulChainlinkOracleMock, StatefulChainlinkOracleMock__factory } from '@typechained';
+import {
+  FeedRegistryInterface,
+  IAccessControl__factory,
+  IERC165__factory,
+  IERC20__factory,
+  IStatefulChainlinkOracle__factory,
+  ITokenPriceOracle__factory,
+  Multicall__factory,
+  StatefulChainlinkOracleMock,
+  StatefulChainlinkOracleMock__factory,
+} from '@typechained';
 import { snapshot } from '@utils/evm';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { FakeContract, smock } from '@defi-wonderland/smock';
@@ -180,45 +190,6 @@ describe('StatefulChainlinkOracle', () => {
     });
   });
 
-  describe('addOrModifySupportForPair', () => {
-    when(`the function is called`, () => {
-      given(async () => {
-        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
-        await chainlinkOracle.addOrModifySupportForPair(TOKEN_A, TOKEN_B, []);
-      });
-      then(`then the internal add support is called directly`, async () => {
-        expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.true;
-      });
-    });
-  });
-
-  describe('addSupportForPairIfNeeded', () => {
-    when('a plan is already defined', () => {
-      given(async () => {
-        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
-        await chainlinkOracle.internalAddSupportForPair(TOKEN_A, TOKEN_B);
-        await chainlinkOracle.reset(TOKEN_A, TOKEN_B);
-      });
-      then('internal add support is not called', async () => {
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B, []);
-        expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.false;
-      });
-      then('internal add support is not called even if tokens are inverted', async () => {
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_B, TOKEN_A, []);
-        expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.false;
-      });
-    });
-    when('pair is not defined yet', () => {
-      given(async () => {
-        await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, A_PLAN);
-        await chainlinkOracle.addSupportForPairIfNeeded(TOKEN_A, TOKEN_B, []);
-      });
-      then('internal add support is called', async () => {
-        expect(await chainlinkOracle.addSupportForPairCalled(TOKEN_A, TOKEN_B)).to.be.true;
-      });
-    });
-  });
-
   describe('internalAddSupportForPair', () => {
     when('no plan can be found for pair', () => {
       given(async () => {
@@ -238,7 +209,7 @@ describe('StatefulChainlinkOracle', () => {
       let tx: TransactionResponse;
       given(async () => {
         await chainlinkOracle.setPricingPlan(TOKEN_A, TOKEN_B, SOME_OTHER_PLAN);
-        tx = await chainlinkOracle.internalAddSupportForPair(TOKEN_A, TOKEN_B);
+        tx = await chainlinkOracle.internalAddOrModifySupportForPair(TOKEN_A, TOKEN_B, []);
       });
       then(`it is marked as the new plan`, async () => {
         expect(await chainlinkOracle.planForPair(TOKEN_A, TOKEN_B)).to.eql(SOME_OTHER_PLAN);
@@ -353,6 +324,43 @@ describe('StatefulChainlinkOracle', () => {
       addressWithRole: () => admin,
     });
   });
+
+  describe('supportsInterface', () => {
+    behaviours.shouldSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'IERC165',
+      interface: IERC165__factory.createInterface(),
+    });
+    behaviours.shouldSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'Multicall',
+      interface: Multicall__factory.createInterface(),
+    });
+    behaviours.shouldSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'ITokenPriceOracle',
+      interface: ITokenPriceOracle__factory.createInterface(),
+    });
+    behaviours.shouldSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'ITransformerOracle',
+      interface: {
+        actual: IStatefulChainlinkOracle__factory.createInterface(),
+        inheritedFrom: [ITokenPriceOracle__factory.createInterface()],
+      },
+    });
+    behaviours.shouldSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'IAccessControl',
+      interface: IAccessControl__factory.createInterface(),
+    });
+    behaviours.shouldNotSupportInterface({
+      contract: () => chainlinkOracle,
+      interfaceName: 'IERC20',
+      interface: IERC20__factory.createInterface(),
+    });
+  });
+
   describe('intercalCallRegistry', () => {
     when('price is negative', () => {
       given(() => makeRegistryReturn({ price: -1 }));

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -198,9 +198,9 @@ describe('StatefulChainlinkOracle', () => {
       then('tx is reverted with reason', async () => {
         await behaviours.txShouldRevertWithMessage({
           contract: chainlinkOracle,
-          func: 'internalAddSupportForPair',
-          args: [TOKEN_A, TOKEN_B],
-          message: 'PairNotSupported',
+          func: 'internalAddOrModifySupportForPair',
+          args: [TOKEN_A, TOKEN_B, []],
+          message: 'PairCannotBeSupported',
         });
       });
     });


### PR DESCRIPTION
We are now making the oracle simpler by implementing `SimpleOracle` and removing some extra logic