### PR TITLE
fix: add ability to lose support

### DIFF
--- a/solidity/contracts/test/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/test/StatefulChainlinkOracle.sol
@@ -29,7 +29,7 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
     _addOrModifySupportForPair(_tokenA, _tokenB, _data);
   }
 
-  function setPricingPlan(
+  function determinePricingPlan(
     address _tokenA,
     address _tokenB,
     PricingPlan _plan

--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -27,10 +27,11 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
     TOKEN_A_TO_ETH_TO_USD_TO_TOKEN_B
   }
 
-  /// @notice Emitted when the oracle add supports for a new pair
+  /// @notice Emitted when the oracle updated the pricing plan for a pair
   /// @param tokenA One of the pair's tokens
   /// @param tokenB The other of the pair's tokens
-  event AddedSupportForPairInChainlinkOracle(address tokenA, address tokenB);
+  /// @param plan The new plan
+  event UpdatedPlanForPair(address tokenA, address tokenB, PricingPlan plan);
 
   /// @notice Emitted when new tokens are considered USD
   /// @param tokens The new tokens


### PR DESCRIPTION
Thanks to @0xged , we realized that we had a corner case where the oracle wouldn't work as expected. This scenario could happen if we removed a mapping (to USD or another token) and suddenly a pair lost support. 

In that case, the pricing plan was already set, and we couldn't remove it by reconfiguring the pair (because it reverted). With this change, we can now lose support 