### PR TITLE
refactor: store plan for mapped

### DIFF
--- a/solidity/contracts/test/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/test/StatefulChainlinkOracle.sol
@@ -61,7 +61,7 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
     }
   }
 
-  function isUSD(address _token) external view returns (bool) {
+  function isUSD(address _token) external pure returns (bool) {
     return _isUSD(_token);
   }
 }

--- a/test/integration/comprehensive-oracle-test.spec.ts
+++ b/test/integration/comprehensive-oracle-test.spec.ts
@@ -274,7 +274,7 @@ describe('Comprehensive Oracle Test', () => {
     const admin = await wallet.impersonate(msig);
     await wallet.setBalance({ account: admin._address, balance: constants.MaxUint256 });
     const oracle = await ethers.getContract<StatefulChainlinkOracle>('StatefulChainlinkOracle');
-    await oracle.connect(admin).addUSDStablecoins([address]);
+    await oracle.connect(admin).addMappings([address], ['0x0000000000000000000000000000000000000348']);
   }
 
   async function fork({ chain, blockNumber }: { chain: string; blockNumber?: number }): Promise<void> {

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -226,7 +226,7 @@ describe('StatefulChainlinkOracle', () => {
         tx = await chainlinkOracle.connect(admin).addUSDStablecoins([TOKEN_ADDRESS]);
       });
       then('address is considered USD', async () => {
-        expect(await chainlinkOracle.isUSD(TOKEN_ADDRESS)).to.be.true;
+        expect(await chainlinkOracle.isUSD(TOKEN_ADDRESS)).to.be.false;
       });
       then('event is emitted', async () => {
         await expect(tx).to.emit(chainlinkOracle, 'TokensConsideredUSD').withArgs([TOKEN_ADDRESS]);


### PR DESCRIPTION
We are now making a change so that plans are stored for the mapped version of a pair. This has a few benefits:

1. If a register the pair WETH/DAI, then it will associated to ETH/USD
2. This means that WETH/USDT already has a plan calculated
3. If we remove the mapping USDT => USDT, then all pairs X/USDT will stop working, until they are reconfigured

_Note: if two tokens are mapped to the same address, then we will use their original version. This is so that stablecoin to stablecoin pairs used their feeds, and we don't assume that they are 1:1_