### PR TITLE
refactor: support same tokens pair

### DIFF
--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -26,7 +26,9 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
     // Will use tokenA/USD, tokenB/ETH and ETH/USD feeds
     TOKEN_A_TO_USD_TO_ETH_TO_TOKEN_B,
     // Will use tokenA/ETH, tokenB/USD and ETH/USD feeds
-    TOKEN_A_TO_ETH_TO_USD_TO_TOKEN_B
+    TOKEN_A_TO_ETH_TO_USD_TO_TOKEN_B,
+    // Used then tokenA is the same as tokenB
+    SAME_TOKENS
   }
 
   /**

--- a/test/integration/stateful-chainlink-oracle.spec.ts
+++ b/test/integration/stateful-chainlink-oracle.spec.ts
@@ -48,7 +48,7 @@ const PLANS: { tokenIn: Token; tokenOut: Token }[][] = [
   [
     // TOKEN_TO_USD_TO_TOKEN_PAIR
     { tokenIn: WBTC, tokenOut: COMP }, // IN (tokenA) => USD => OUT (tokenB)
-    { tokenIn: USDT, tokenOut: USDC }, // IN (tokenB) => USD => OUT (tokenA)
+    { tokenIn: CRV, tokenOut: AAVE }, // IN (tokenB) => USD => OUT (tokenA)
   ],
   [
     // TOKEN_TO_ETH_TO_TOKEN_PAIR
@@ -78,6 +78,11 @@ const PLANS: { tokenIn: Token; tokenOut: Token }[][] = [
 
     { tokenIn: AXS, tokenOut: AMP }, // IN (tokenA) => ETH, USD => OUT (tokenB)
     { tokenIn: FXS, tokenOut: BOND }, // IN (tokenB) => USD, ETH => OUT (tokenA)
+  ],
+  [
+    // SAME_TOKENS
+    { tokenIn: USDT, tokenOut: USDC }, // tokenA is USD, tokenB is USD
+    { tokenIn: ALPHA, tokenOut: ALPHA }, // tokenA == token B
   ],
 ];
 

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -123,6 +123,11 @@ describe('StatefulChainlinkOracle', () => {
         expect(await chainlinkOracle.canSupportPair(TOKEN_B, TOKEN_A)).to.be.true;
       });
     });
+    when('tokens are the same', () => {
+      then('pair is supported', async () => {
+        expect(await chainlinkOracle.canSupportPair(TOKEN_A, TOKEN_A)).to.be.true;
+      });
+    });
   });
 
   describe('isPairAlreadySupported', () => {


### PR DESCRIPTION
Before this change, we couldn't quote two tokens that mapped to the same address. It would work only if they had their own individual feeds

So the idea here is that if two tokens maps to the same address, then we consider them the same, and we will quote 1:1. We should now be very careful in what we map to other addresses