### PR TITLE
refactor: make max delay constant

### DIFF
--- a/deploy/001_stateful_chainlink_oracle.ts
+++ b/deploy/001_stateful_chainlink_oracle.ts
@@ -1,30 +1,11 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from '@0xged/hardhat-deploy/types';
-import moment from 'moment';
-import { BigNumber, BigNumberish } from 'ethers';
 import { bytecode } from '../artifacts/solidity/contracts/StatefulChainlinkOracle.sol/StatefulChainlinkOracle.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, msig } = await hre.getNamedAccounts();
   const registry = await hre.deployments.get('ChainlinkFeedRegistry');
-
-  let maxDelay: BigNumberish;
-
-  switch (hre.deployments.getNetworkName()) {
-    case 'ethereum':
-    case 'optimism':
-    case 'polygon':
-    case 'arbitrum':
-      maxDelay = moment.duration('1', 'day').asSeconds();
-      break;
-    case 'optimism-kovan':
-    case 'polygon-mumbai':
-      maxDelay = BigNumber.from(2).pow(32).sub(1); // Max possible
-      break;
-    default:
-      throw new Error(`Unsupported chain '${hre.network.name}`);
-  }
 
   await deployThroughDeterministicFactory({
     deployer,
@@ -33,8 +14,8 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     contract: 'solidity/contracts/StatefulChainlinkOracle.sol:StatefulChainlinkOracle',
     bytecode,
     constructorArgs: {
-      types: ['address', 'uint32', 'address', 'address[]'],
-      values: [registry.address, maxDelay, msig, [msig]],
+      types: ['address', 'address', 'address[]'],
+      values: [registry.address, msig, [msig]],
     },
     log: !process.env.TEST,
     overrides: !!process.env.COVERAGE

--- a/solidity/contracts/test/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/test/StatefulChainlinkOracle.sol
@@ -14,10 +14,9 @@ contract StatefulChainlinkOracleMock is StatefulChainlinkOracle {
 
   constructor(
     FeedRegistryInterface _registry,
-    uint32 _maxDelay,
     address _superAdmin,
     address[] memory _initialAdmins
-  ) StatefulChainlinkOracle(_registry, _maxDelay, _superAdmin, _initialAdmins) {}
+  ) StatefulChainlinkOracle(_registry, _superAdmin, _initialAdmins) {}
 
   function internalAddOrModifySupportForPair(
     address _tokenA,

--- a/solidity/interfaces/IStatefulChainlinkOracle.sol
+++ b/solidity/interfaces/IStatefulChainlinkOracle.sol
@@ -58,12 +58,6 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
    */
   event MappingsAdded(address[] tokens, address[] mappings);
 
-  /**
-   * @notice Emitted when a new max delay is set
-   * @param newMaxDelay The new max delay
-   */
-  event MaxDelaySet(uint32 newMaxDelay);
-
   /// @notice Thrown when the price is non-positive
   error InvalidPrice();
 
@@ -73,23 +67,21 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();
 
-  /// @notice Thrown when the given max delay is zero
-  error ZeroMaxDelay();
-
   /// @notice Thrown when the input for adding mappings in invalid
   error InvalidMappingsInput();
+
+  /**
+   * @notice Returns how old the last price update can be before the oracle reverts by considering it too old
+   * @dev Cannot be modified
+   * @return How old the last price update can be in seconds
+   */
+  function MAX_DELAY() external view returns (uint32);
 
   /**
    * @notice Returns the Chainlink feed registry
    * @return The Chainlink registry
    */
   function registry() external view returns (FeedRegistryInterface);
-
-  /**
-   * @notice Returns how old the last price update can be before the oracle reverts by considering it too old
-   * @return How old the last price update can be in seconds
-   */
-  function maxDelay() external view returns (uint32);
 
   /**
    * @notice Returns the pricing plan that will be used when quoting the given pair
@@ -110,10 +102,4 @@ interface IStatefulChainlinkOracle is ITokenPriceOracle {
    * @param mappings The addresses of their mappings
    */
   function addMappings(address[] calldata addresses, address[] calldata mappings) external;
-
-  /**
-   * @notice Sets a new max delay
-   * @param maxDelay The new max delay
-   */
-  function setMaxDelay(uint32 maxDelay) external;
 }

--- a/test/unit/stateful-chainlink-oracle.spec.ts
+++ b/test/unit/stateful-chainlink-oracle.spec.ts
@@ -20,7 +20,7 @@ import { FakeContract, smock } from '@defi-wonderland/smock';
 import moment from 'moment';
 import { constants } from 'ethers';
 
-describe.only('StatefulChainlinkOracle', () => {
+describe('StatefulChainlinkOracle', () => {
   const ONE_DAY = moment.duration('24', 'hours').asSeconds();
   const TOKEN_A = '0x0000000000000000000000000000000000000001';
   const TOKEN_B = '0x0000000000000000000000000000000000000002';


### PR DESCRIPTION
Before this change, we were able to configure the max delay allowed for Chainlink feeds. The thing is that for all networks, the max delay was 24hs 😅 

I went over most Chainlink feeds and in fact, the max delay is 24hs. But, at the same time, `maxDelay` was mutable, so we were reading storage once for each read feed. And we could potentially read 4 feeds per pair

So the idea is to simplify everything by just hardcoding the max 24hs delay. In an ideal world (alpha drop), we would use the actual feed heartbeat instead of a max delay that covers all feeds