### PR TITLE
chore: remove unrelated comment

### DIFF
--- a/solidity/contracts/StatefulChainlinkOracle.sol
+++ b/solidity/contracts/StatefulChainlinkOracle.sol
@@ -212,8 +212,6 @@ contract StatefulChainlinkOracle is AccessControl, SimpleOracle, IStatefulChainl
     bool _isTokenAETH = _isETH(_tokenA);
     bool _isTokenBETH = _isETH(_tokenB);
     if ((_isTokenAETH && _isTokenBUSD) || (_isTokenAUSD && _isTokenBETH)) {
-      // Note: there are stablecoins/ETH pairs on Chainlink, but they are updated less often than the USD/ETH pair.
-      // That's why we prefer to use the USD/ETH pair instead
       return PricingPlan.ETH_USD_PAIR;
     } else if (_isTokenBUSD) {
       return _tryWithBases(_tokenA, PricingPlan.TOKEN_USD_PAIR, PricingPlan.TOKEN_A_TO_ETH_TO_USD_TO_TOKEN_B);


### PR DESCRIPTION
Since we are now longer treating usd stablecoins as a special case, we can remove this comment that doesn't make sense anymore