### PR TITLE
refactor: simplify get transformers

### DIFF
--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -33,14 +33,23 @@ contract TransformerOracleMock is TransformerOracle {
     _transformersForPair[_tokenA][_tokenB] = [_transformerTokenA, _transformerTokenB];
   }
 
-  function internalGetTransformers(address _tokenA, address _tokenB) external view returns (ITransformer[] memory) {
+  function internalGetTransformers(address _tokenA, address _tokenB)
+    external
+    view
+    returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB)
+  {
     return _getTransformers(_tokenA, _tokenB);
   }
 
-  function _getTransformers(address _tokenA, address _tokenB) internal view override returns (ITransformer[] memory) {
+  function _getTransformers(address _tokenA, address _tokenB)
+    internal
+    view
+    override
+    returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB)
+  {
     ITransformer[] memory _transformers = _transformersForPair[_tokenA][_tokenB];
     if (_transformers.length > 0) {
-      return _transformers;
+      return (_transformers[0], _transformers[1]);
     } else {
       return super._getTransformers(_tokenA, _tokenB);
     }

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -23,7 +23,7 @@ import { TransactionResponse } from '@ethersproject/providers';
 
 chai.use(smock.matchers);
 
-describe('TransformerOracle', () => {
+describe.only('TransformerOracle', () => {
   const TOKEN_A = '0x0000000000000000000000000000000000000001';
   const TOKEN_B = '0x0000000000000000000000000000000000000002';
   const UNDERLYING_TOKEN_A = '0x0000000000000000000000000000000000000003';
@@ -469,8 +469,8 @@ describe('TransformerOracle', () => {
         await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A, TOKEN_B]);
         transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
       });
-      then('registry is never called', () => {
-        expect(registry.transformers).to.not.have.been.called;
+      then('registry is called correctly', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
       });
       then('zero addresses are returned', () => {
         expect(transformers).to.eql([constants.AddressZero, constants.AddressZero]);
@@ -482,8 +482,8 @@ describe('TransformerOracle', () => {
         await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_A]);
         transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
       });
-      then('registry is called for tokenB', () => {
-        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_B]);
+      then('registry is called correctly', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
       });
       then('tokenB is mapped', () => {
         expect(transformers).to.eql([constants.AddressZero, UNDERLYING_TOKEN_B]);
@@ -495,8 +495,8 @@ describe('TransformerOracle', () => {
         await transformerOracle.connect(admin).avoidMappingToUnderlying([TOKEN_B]);
         transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
       });
-      then('registry is called for tokenA', () => {
-        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A]);
+      then('registry is called correctly', () => {
+        expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
       });
       then('tokenA is mapped', () => {
         expect(transformers).to.eql([UNDERLYING_TOKEN_A, constants.AddressZero]);
@@ -507,7 +507,7 @@ describe('TransformerOracle', () => {
       given(async () => {
         transformers = await transformerOracle.internalGetTransformers(TOKEN_A, TOKEN_B);
       });
-      then('registry is called for tokenA and tokenB', () => {
+      then('registry is called correctly', () => {
         expect(registry.transformers).to.have.been.calledOnceWith([TOKEN_A, TOKEN_B]);
       });
       then('both tokens are mapped', () => {

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -23,7 +23,7 @@ import { TransactionResponse } from '@ethersproject/providers';
 
 chai.use(smock.matchers);
 
-describe.only('TransformerOracle', () => {
+describe('TransformerOracle', () => {
   const TOKEN_A = '0x0000000000000000000000000000000000000001';
   const TOKEN_B = '0x0000000000000000000000000000000000000002';
   const UNDERLYING_TOKEN_A = '0x0000000000000000000000000000000000000003';


### PR DESCRIPTION
We are now simplifying `_getTransformers` so that it's easier to read and maintain