### PR TITLE
feat: clear specific mapping config

### DIFF
--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -95,6 +95,17 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
     emit PairSpecificConfigSet(_config);
   }
 
+  /// @inheritdoc ITransformerOracle
+  function clearPairSpecificMappingConfig(Pair[] calldata _pairs) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i = 0; i < _pairs.length; ) {
+      delete _pairSpecificMappingConfig[_keyForPair(_pairs[i].tokenA, _pairs[i].tokenB)];
+      unchecked {
+        i++;
+      }
+    }
+    emit PairSpecificConfigCleared(_pairs);
+  }
+
   /// @inheritdoc ITokenPriceOracle
   function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
     (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);

--- a/solidity/interfaces/ITransformerOracle.sol
+++ b/solidity/interfaces/ITransformerOracle.sol
@@ -35,6 +35,14 @@ interface ITransformerOracle is ITokenPriceOracle {
     bool mapTokenBToUnderlying;
   }
 
+  /// @notice A pair of tokens
+  struct Pair {
+    // One of the pair's tokens
+    address tokenA;
+    // The other of the pair's tokens
+    address tokenB;
+  }
+
   /// @notice Thrown when a parameter is the zero address
   error ZeroAddress();
 
@@ -55,6 +63,12 @@ interface ITransformerOracle is ITokenPriceOracle {
    * @param config The config that was set
    */
   event PairSpecificConfigSet(PairSpecificMappingConfigToSet[] config);
+
+  /**
+   * @notice Emitted when dependents pair-specific mapping config is cleared
+   * @param pairs The pairs that had their config cleared
+   */
+  event PairSpecificConfigCleared(Pair[] pairs);
 
   /**
    * @notice Returns the address of the transformer registry
@@ -117,4 +131,10 @@ interface ITransformerOracle is ITokenPriceOracle {
    * @param config A list of pairs to configure
    */
   function setPairSpecificMappingConfig(PairSpecificMappingConfigToSet[] calldata config) external;
+
+  /**
+   * @notice Cleares any pair-specific mapping config for the given list of pairs
+   * @param pairs The pairs that will have their config cleared
+   */
+  function clearPairSpecificMappingConfig(Pair[] calldata pairs) external;
 }


### PR DESCRIPTION
We are now adding the possibility to clear pair-specific mapping config for a pair