### PR TITLE
refactor: get transformers optimized

### DIFF
--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -229,6 +229,11 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
     }
   }
 
+  /**
+   * @dev We have the transformers for tokenA and tokenB, but maybe, based on the config, we don't want to map these tokens to their underlying.
+   *      For example, this is normally the case for WETH and ETH. So this function will take the transformers and, based on the config, return
+   *      the fetched transformers or the zero address
+   */
   function _hideTransformersBasedOnConfig(
     address _tokenA,
     address _tokenB,

--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -33,25 +33,35 @@ contract TransformerOracleMock is TransformerOracle {
     _transformersForPair[_tokenA][_tokenB] = [_transformerTokenA, _transformerTokenB];
   }
 
-  function internalGetTransformers(address _tokenA, address _tokenB)
-    external
-    view
-    returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB)
-  {
-    return _getTransformers(_tokenA, _tokenB);
+  function internalFetchTransformers(
+    address _tokenA,
+    address _tokenB,
+    bool _shouldCheckA,
+    bool _shouldCheckB
+  ) external view returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB) {
+    return _fetchTransformers(_tokenA, _tokenB, _shouldCheckA, _shouldCheckB);
   }
 
-  function _getTransformers(address _tokenA, address _tokenB)
-    internal
-    view
-    override
-    returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB)
-  {
+  function internalHideTransformersBasedOnConfig(
+    address _tokenA,
+    address _tokenB,
+    ITransformer _transformerTokenA,
+    ITransformer _transformerTokenB
+  ) external view returns (ITransformer, ITransformer) {
+    return _hideTransformersBasedOnConfig(_tokenA, _tokenB, _transformerTokenA, _transformerTokenB);
+  }
+
+  function _getTransformersOptimized(
+    address _tokenA,
+    address _tokenB,
+    bool _shouldCheckA,
+    bool _shouldCheckB
+  ) internal view override returns (ITransformer _transformerTokenA, ITransformer _transformerTokenB) {
     ITransformer[] memory _transformers = _transformersForPair[_tokenA][_tokenB];
     if (_transformers.length > 0) {
       return (_transformers[0], _transformers[1]);
     } else {
-      return super._getTransformers(_tokenA, _tokenB);
+      return super._getTransformersOptimized(_tokenA, _tokenB, _shouldCheckA, _shouldCheckB);
     }
   }
 

--- a/test/integration/transformer-oracle.spec.ts
+++ b/test/integration/transformer-oracle.spec.ts
@@ -19,7 +19,7 @@ const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const STETH = '0xae7ab96520de3a18e5e111b5eaab095312d7fe84';
 const WSTETH = '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0';
 
-describe.only('TransformerOracle', () => {
+describe('TransformerOracle', () => {
   let oracle: TransformerOracle;
   let transformerRegistry: TransformerRegistry;
   let admin: JsonRpcSigner;

--- a/test/unit/transformer-oracle.spec.ts
+++ b/test/unit/transformer-oracle.spec.ts
@@ -25,7 +25,7 @@ import { readArgFromEventOrFail } from '@utils/event-utils';
 
 chai.use(smock.matchers);
 
-describe.only('TransformerOracle', () => {
+describe('TransformerOracle', () => {
   const TOKEN_A = '0x0000000000000000000000000000000000000001';
   const TOKEN_B = '0x0000000000000000000000000000000000000002';
   const UNDERLYING_TOKEN_A = '0x0000000000000000000000000000000000000003';


### PR DESCRIPTION
We are now doing a small refactor to introduce `_getTransformersOptimized`. The idea is simple, if we know before hand if a token doesn't have an underlying, then we can avoid fetching its transformer. This would make the call a little cheaper

So what we did was:
- Introduced `_fetchTransformers` that fetches between 0 and 2 transformers, based on the params
- Moved transformer hiding logic to `_hideTransformersBasedOnConfig`
- Introduced `_getTransformersOptimized`, which basically calls `_fetchTransformers` & `_hideTransformersBasedOnConfig`

This change might not make sense yet, since we are not using it, but it will on a following PR