### PR TITLE
refactor: use recursive

### DIFF
--- a/solidity/contracts/TransformerOracle.sol
+++ b/solidity/contracts/TransformerOracle.sol
@@ -118,13 +118,13 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
 
   /// @inheritdoc ITokenPriceOracle
   function canSupportPair(address _tokenA, address _tokenB) external view returns (bool) {
-    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getRecursiveMappingForPair(_tokenA, _tokenB);
     return UNDERLYING_ORACLE.canSupportPair(_mappedTokenA, _mappedTokenB);
   }
 
   /// @inheritdoc ITokenPriceOracle
   function isPairAlreadySupported(address _tokenA, address _tokenB) external view returns (bool) {
-    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getRecursiveMappingForPair(_tokenA, _tokenB);
     return UNDERLYING_ORACLE.isPairAlreadySupported(_mappedTokenA, _mappedTokenB);
   }
 
@@ -160,7 +160,7 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getRecursiveMappingForPair(_tokenA, _tokenB);
     UNDERLYING_ORACLE.addOrModifySupportForPair(_mappedTokenA, _mappedTokenB, _data);
   }
 
@@ -170,7 +170,7 @@ contract TransformerOracle is BaseOracle, AccessControl, ITransformerOracle {
     address _tokenB,
     bytes calldata _data
   ) external {
-    (address _mappedTokenA, address _mappedTokenB) = getMappingForPair(_tokenA, _tokenB);
+    (address _mappedTokenA, address _mappedTokenB) = getRecursiveMappingForPair(_tokenA, _tokenB);
     UNDERLYING_ORACLE.addSupportForPairIfNeeded(_mappedTokenA, _mappedTokenB, _data);
   }
 

--- a/solidity/contracts/test/TransformerOracle.sol
+++ b/solidity/contracts/test/TransformerOracle.sol
@@ -73,4 +73,18 @@ contract TransformerOracleMock is TransformerOracle {
       return (_mapping[0], _mapping[1]);
     }
   }
+
+  function getRecursiveMappingForPair(address _tokenA, address _tokenB)
+    public
+    view
+    override
+    returns (address _mappedTokenA, address _mappedTokenB)
+  {
+    address[] memory _mapping = _mappingForPair[_tokenA][_tokenB];
+    if (_mapping.length == 0) {
+      return super.getRecursiveMappingForPair(_tokenA, _tokenB);
+    } else {
+      return (_mapping[0], _mapping[1]);
+    }
+  }
 }


### PR DESCRIPTION
We are now using `getRecursiveMappingForPair` instead of `getMappingForPair` on:
- `canSupportPair`
- `isPairAlreadySupported`
- `addOrModifySupportForPair`
- `addSupportForPairIfNeeded`

Note: we still need to update `quote`, which will be done in a following PR