### PR TITLE
feat: add api3 adapter factory

### DIFF
--- a/deploy/006_api3_chainlink_adapter_factory.ts
+++ b/deploy/006_api3_chainlink_adapter_factory.ts
@@ -1,0 +1,30 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { bytecode } from '../artifacts/solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol/API3ChainlinkAdapterFactory.json';
+import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
+import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
+
+const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer } = await hre.getNamedAccounts();
+
+  await deployThroughDeterministicFactory({
+    deployer,
+    name: 'API3ChainlinkAdapterFactory',
+    salt: 'MF-Transformer-Oracle-V2',
+    contract: 'solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol:API3ChainlinkAdapterFactory',
+    bytecode,
+    constructorArgs: {
+      types: [],
+      values: [],
+    },
+    log: !process.env.TEST,
+    overrides: !!process.env.COVERAGE
+      ? {}
+      : {
+          gasLimit: 15_000_000,
+        },
+  });
+};
+
+deployFunction.dependencies = [];
+deployFunction.tags = ['API3ChainlinkAdapterFactory'];
+export default deployFunction;

--- a/solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol
+++ b/solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import './API3ChainlinkAdapter.sol';
+
+contract API3ChainlinkAdapterFactory {
+  /// @notice Emitted when a new adapter is deployed
+  event AdapterCreated(API3ChainlinkAdapter adapter);
+
+  function createAdapter(IProxy _api3Proxy, string calldata _description) external returns (API3ChainlinkAdapter _adapter) {
+    _adapter = new API3ChainlinkAdapter{salt: bytes32(0)}(_api3Proxy, _description);
+    emit AdapterCreated(_adapter);
+  }
+
+  function computeAdapterAddress(IProxy _api3Proxy, string calldata _description) external view returns (address _adapter) {
+    return
+      _computeCreate2Address(
+        keccak256(
+          abi.encodePacked(
+            // Deployment bytecode:
+            type(API3ChainlinkAdapter).creationCode,
+            // Constructor arguments:
+            abi.encode(_api3Proxy, _description)
+          )
+        )
+      );
+  }
+
+  function _computeCreate2Address(bytes32 _bytecodeHash) internal view virtual returns (address) {
+    // Prefix:
+    // Creator:
+    // Salt:
+    // Bytecode hash:
+    return fromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xFF), address(this), bytes32(0), _bytecodeHash)));
+  }
+
+  function fromLast20Bytes(bytes32 _bytesValue) internal pure returns (address) {
+    // Convert the CREATE2 hash into an address.
+    return address(uint160(uint256(_bytesValue)));
+  }
+}

--- a/solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol
+++ b/solidity/contracts/adapters/api3-chainlink-adapter/API3ChainlinkAdapterFactory.sol
@@ -7,12 +7,20 @@ contract API3ChainlinkAdapterFactory {
   /// @notice Emitted when a new adapter is deployed
   event AdapterCreated(API3ChainlinkAdapter adapter);
 
-  function createAdapter(IProxy _api3Proxy, string calldata _description) external returns (API3ChainlinkAdapter _adapter) {
-    _adapter = new API3ChainlinkAdapter{salt: bytes32(0)}(_api3Proxy, _description);
+  function createAdapter(
+    IProxy _api3Proxy,
+    uint8 _decimals,
+    string calldata _description
+  ) external returns (API3ChainlinkAdapter _adapter) {
+    _adapter = new API3ChainlinkAdapter{salt: bytes32(0)}(_api3Proxy, _decimals, _description);
     emit AdapterCreated(_adapter);
   }
 
-  function computeAdapterAddress(IProxy _api3Proxy, string calldata _description) external view returns (address _adapter) {
+  function computeAdapterAddress(
+    IProxy _api3Proxy,
+    uint8 _decimals,
+    string calldata _description
+  ) external view returns (address _adapter) {
     return
       _computeCreate2Address(
         keccak256(
@@ -20,7 +28,7 @@ contract API3ChainlinkAdapterFactory {
             // Deployment bytecode:
             type(API3ChainlinkAdapter).creationCode,
             // Constructor arguments:
-            abi.encode(_api3Proxy, _description)
+            abi.encode(_api3Proxy, _decimals, _description)
           )
         )
       );

--- a/test/integration/api3_chainlink_adapter.spec.ts
+++ b/test/integration/api3_chainlink_adapter.spec.ts
@@ -1,0 +1,131 @@
+import { deployments, ethers, getNamedAccounts } from 'hardhat';
+import { evm, wallet } from '@utils';
+import { API3ChainlinkAdapter, API3ChainlinkAdapterFactory, API3ChainlinkAdapter__factory, StatefulChainlinkOracle } from '@typechained';
+import { BigNumber, BytesLike, constants, utils } from 'ethers';
+import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory';
+import { address as DETERMINISTIC_FACTORY_ADDRESS } from '@mean-finance/deterministic-factory/deployments/ethereum/DeterministicFactory.json';
+import { JsonRpcSigner } from '@ethersproject/providers';
+import { expect } from 'chai';
+import { given, then, when } from '@utils/bdd';
+import { snapshot } from '@utils/evm';
+import { convertPriceToBigNumberWithDecimals, getTokenData } from '@utils/defillama';
+import { ChainlinkRegistry } from '@mean-finance/chainlink-registry/dist';
+
+const BLOCK_NUMBER = 43876587;
+const EMPTY_BYTES: BytesLike = [];
+const DAI = '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063';
+const USD = '0x0000000000000000000000000000000000000348';
+
+// Skipped because hardhat caches chain data, so if we try to test this on Polygon and then other tests use Ethereum, everything breakes
+// Tried a few workarounds, but failed :( So we will simply disable this test and run it manually when necessary. Also, we can't test this
+// on Ethereum since there are no funded/active feeds at the moment
+describe.skip('API3ChainlinkAdapter', () => {
+  let factory: API3ChainlinkAdapterFactory;
+  let oracle: StatefulChainlinkOracle;
+  let registry: ChainlinkRegistry;
+  let admin: JsonRpcSigner;
+  let snapshotId: string;
+
+  before(async () => {
+    // Fork and deploy
+    await fork({ chain: 'polygon', blockNumber: BLOCK_NUMBER });
+    await deployments.run(['ChainlinkFeedRegistry', 'StatefulChainlinkOracle', 'API3ChainlinkAdapterFactory'], {
+      resetMemory: true,
+      deletePreviousDeployments: false,
+      writeDeploymentsToFiles: false,
+    });
+    const { msig } = await getNamedAccounts();
+    admin = await wallet.impersonate(msig);
+
+    // Set up contracts
+    factory = await ethers.getContract<API3ChainlinkAdapterFactory>('API3ChainlinkAdapterFactory');
+    registry = await ethers.getContract<ChainlinkRegistry>('ChainlinkFeedRegistry');
+    oracle = await ethers.getContract<StatefulChainlinkOracle>('StatefulChainlinkOracle');
+
+    // Set up DAI feed
+    await registry.connect(admin).assignFeeds([{ base: DAI, quote: USD, feed: '0x4746DeC9e833A82EC7C2C1356372CcF2cfcD2F3D' }]);
+
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  adapterTest({
+    symbol: 'LDO',
+    address: '0xC3C7d422809852031b44ab29EEC9F1EfF2A58756',
+    proxy: '0x774F0C833ceaacA9b472771FfBE3ada4d6805709',
+  });
+
+  adapterTest({
+    symbol: 'SAND',
+    address: '0xBbba073C31bF03b8ACf7c28EF0738DeCF3695683',
+    proxy: '0x1bF3b112556a536d4C051a014B439d1F34cf4CD8',
+  });
+
+  function adapterTest({ address, symbol, proxy }: { address: string; symbol: string; proxy: string }) {
+    when(`using an adapter for ${symbol}`, () => {
+      let adapter: API3ChainlinkAdapter;
+      given(async () => {
+        // Set up adapter
+        await factory.createAdapter(proxy, 8, `${symbol}/USD`);
+        const adapterAddress = await factory.computeAdapterAddress(proxy, 8, `${symbol}/USD`);
+        adapter = API3ChainlinkAdapter__factory.connect(adapterAddress, ethers.provider);
+
+        // Add to registry
+        await registry.connect(admin).assignFeeds([{ base: address, quote: USD, feed: adapter.address }]);
+
+        // Prepare support
+        await oracle.addSupportForPairIfNeeded(address, DAI, EMPTY_BYTES);
+      });
+      then('quote is calculated correctly', async () => {
+        const quote = await oracle.quote(address, utils.parseEther('1'), DAI, EMPTY_BYTES);
+        await validateQuote(quote, address, DAI);
+      });
+      then('description is set correctly', async () => {
+        expect(await adapter.description()).to.equal(`${symbol}/USD`);
+      });
+      then('decimals are set correctly', async () => {
+        expect(await adapter.decimals()).to.equal(8);
+      });
+    });
+  }
+
+  async function validateQuote(quote: BigNumber, tokenIn: string, tokenOut: string, thresholdPercentage?: number) {
+    const { timestamp } = await ethers.provider.getBlock(BLOCK_NUMBER);
+    const tokenInData = await getTokenData('polygon', tokenIn, timestamp);
+    const tokenOutData = await getTokenData('polygon', tokenOut, timestamp);
+    const expectedAmountOut = convertPriceToBigNumberWithDecimals(tokenInData.price / tokenOutData.price, tokenOutData.decimals);
+
+    const TRESHOLD_PERCENTAGE = thresholdPercentage ?? 2; // 2% price diff tolerance
+
+    const threshold = expectedAmountOut.mul(TRESHOLD_PERCENTAGE * 10).div(100 * 10);
+    const [upperThreshold, lowerThreshold] = [expectedAmountOut.add(threshold), expectedAmountOut.sub(threshold)];
+    const diff = quote.sub(expectedAmountOut);
+    const sign = diff.isNegative() ? '-' : '+';
+    const diffPercentage = diff.abs().mul(10000).div(expectedAmountOut).toNumber() / 100;
+
+    expect(
+      quote.lte(upperThreshold) && quote.gte(lowerThreshold),
+      `Expected ${quote.toString()} to be within [${lowerThreshold.toString()},${upperThreshold.toString()}]. Diff was ${sign}${diffPercentage}%`
+    ).to.be.true;
+  }
+
+  async function fork({ chain, blockNumber }: { chain: string; blockNumber?: number }): Promise<void> {
+    // Set fork of network
+    await evm.reset({
+      network: chain,
+      blockNumber,
+    });
+    const { deployer: deployerAddress, msig } = await getNamedAccounts();
+    // Give deployer role to our deployer address
+    const admin = await wallet.impersonate(msig);
+    await wallet.setBalance({ account: admin._address, balance: constants.MaxUint256 });
+    const deterministicFactory = await ethers.getContractAt<DeterministicFactory>(
+      DeterministicFactory__factory.abi,
+      DETERMINISTIC_FACTORY_ADDRESS
+    );
+    await deterministicFactory.connect(admin).grantRole(await deterministicFactory.DEPLOYER_ROLE(), deployerAddress);
+  }
+});

--- a/test/unit/adapters/api3-chainlink-adapter/api3-chainlink-adapter-factory.spec.ts
+++ b/test/unit/adapters/api3-chainlink-adapter/api3-chainlink-adapter-factory.spec.ts
@@ -7,6 +7,7 @@ import { snapshot } from '@utils/evm';
 
 describe('API3ChainlinkAdapterFactory', () => {
   const PROXY = '0x0000000000000000000000000000000000000001';
+  const DECIMALS = 8;
   const DESCRIPTION = 'TOKEN/USD';
 
   let factory: API3ChainlinkAdapterFactory;
@@ -27,8 +28,8 @@ describe('API3ChainlinkAdapterFactory', () => {
       let expectedAddress: string;
       let tx: TransactionResponse;
       given(async () => {
-        expectedAddress = await factory.computeAdapterAddress(PROXY, DESCRIPTION);
-        tx = await factory.createAdapter(PROXY, DESCRIPTION);
+        expectedAddress = await factory.computeAdapterAddress(PROXY, DECIMALS, DESCRIPTION);
+        tx = await factory.createAdapter(PROXY, DECIMALS, DESCRIPTION);
       });
       then('event is emitted', async () => {
         await expect(tx).to.emit(factory, 'AdapterCreated').withArgs(expectedAddress);
@@ -36,15 +37,16 @@ describe('API3ChainlinkAdapterFactory', () => {
       then('contract was deployed correctly', async () => {
         const adapter = API3ChainlinkAdapter__factory.connect(expectedAddress, ethers.provider);
         expect(await adapter.API3_PROXY()).to.equal(PROXY);
+        expect(await adapter.decimals()).to.equal(DECIMALS);
         expect(await adapter.description()).to.equal(DESCRIPTION);
       });
     });
     when('adapter is created twice', () => {
       given(async () => {
-        await factory.createAdapter(PROXY, DESCRIPTION);
+        await factory.createAdapter(PROXY, DECIMALS, DESCRIPTION);
       });
       then('the second time reverts', async () => {
-        const tx = factory.createAdapter(PROXY, DESCRIPTION);
+        const tx = factory.createAdapter(PROXY, DECIMALS, DESCRIPTION);
         await expect(tx).to.have.reverted;
       });
     });

--- a/test/unit/adapters/api3-chainlink-adapter/api3-chainlink-adapter-factory.spec.ts
+++ b/test/unit/adapters/api3-chainlink-adapter/api3-chainlink-adapter-factory.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { given, then, when } from '@utils/bdd';
+import { API3ChainlinkAdapter__factory, API3ChainlinkAdapterFactory__factory, API3ChainlinkAdapterFactory } from '@typechained';
+import { TransactionResponse } from 'ethers/node_modules/@ethersproject/providers';
+import { snapshot } from '@utils/evm';
+
+describe('API3ChainlinkAdapterFactory', () => {
+  const PROXY = '0x0000000000000000000000000000000000000001';
+  const DESCRIPTION = 'TOKEN/USD';
+
+  let factory: API3ChainlinkAdapterFactory;
+  let snapshotId: string;
+
+  before(async () => {
+    const factoryFactory: API3ChainlinkAdapterFactory__factory = await ethers.getContractFactory('API3ChainlinkAdapterFactory');
+    factory = await factoryFactory.deploy();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('createAdapter', () => {
+    when('adapter is created', () => {
+      let expectedAddress: string;
+      let tx: TransactionResponse;
+      given(async () => {
+        expectedAddress = await factory.computeAdapterAddress(PROXY, DESCRIPTION);
+        tx = await factory.createAdapter(PROXY, DESCRIPTION);
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(factory, 'AdapterCreated').withArgs(expectedAddress);
+      });
+      then('contract was deployed correctly', async () => {
+        const adapter = API3ChainlinkAdapter__factory.connect(expectedAddress, ethers.provider);
+        expect(await adapter.API3_PROXY()).to.equal(PROXY);
+        expect(await adapter.description()).to.equal(DESCRIPTION);
+      });
+    });
+    when('adapter is created twice', () => {
+      given(async () => {
+        await factory.createAdapter(PROXY, DESCRIPTION);
+      });
+      then('the second time reverts', async () => {
+        const tx = factory.createAdapter(PROXY, DESCRIPTION);
+        await expect(tx).to.have.reverted;
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now adding a new factory contract for the API3 adapter. This will allow us to deploy adapters more easily. We are using CREATE2 to deploy the contracts, based on the address of the proxy and the description too

_Note: integration tests will be added in the next PR_